### PR TITLE
Fix spelling in configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ the instructions inside `config/parental.guidance.php`.
 #### Tell IMDb which is the preferred language (e.g. en-US, de-DE, pt-BR)
 Sometimes IMDb gets unsure that the specified language are correct, if you only specify your unique language and territory code (de-DE). In the example below, you can find that we have chosen to include `de-DE (German, Germany)`, `de (German)` and `en (English)`. If IMDb can’t find anything matching German, Germany, you will get German results instead or English if there are no German translation.
 ```
-$settings["imdbphp"]["langauge"] = 'de-DE,de,en';
+$settings["imdbphp"]["language"] = 'de-DE,de,en';
 ```
 Please use The Unicode Consortium [Langugage-Territory Information](http://www.unicode.org/cldr/charts/latest/supplemental/language_territory_information.html) database for finding your unique language and territory code.
 
-| Langauge | Code | Territory   | Code |
+| Language | Code | Territory   | Code |
 | -------- | ---- | ----------- | ---- |
 | German   | de   | Germany {O} | DE   |
 

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -222,7 +222,7 @@ $settings['youtube_key'] = '';
  * Any valid language code can be used here (e.g. en-US, de, pt-BR).
  * If this option is specified, a Accept-Language header with this value will be included in requests to IMDb.
  */
-$settings["imdbphp"]["langauge"] = '';
+$settings["imdbphp"]["language"] = '';
 
 /**
  * Set originating IP address of a client connecting to a web server through an HTTP proxy or a load balancer.

--- a/includes/movie.inc.php
+++ b/includes/movie.inc.php
@@ -57,8 +57,8 @@ if($loggedin && $User->isEditor() && $imdbid = getValidId('imdbid',true)) {
 	
 	// IMDB config
 	$config = new \Imdb\Config();
-	if($settings["imdbphp"]["langauge"])
-		$config->language = $settings["imdbphp"]["langauge"];
+	if($settings["imdbphp"]["language"])
+		$config->language = $settings["imdbphp"]["language"];
 	if($settings["imdbphp"]["ip_address"])
 		$config->ip_address = $settings["imdbphp"]["ip_address"];
 	if($settings["imdbphp"]["debug"])

--- a/includes/movie.update.inc.php
+++ b/includes/movie.update.inc.php
@@ -22,8 +22,8 @@ if(isset($_GET["imdbsearch"])) {
 		
 		// IMDB config
 		$config = new \Imdb\Config();
-		if($settings["imdbphp"]["langauge"])
-			$config->language = $settings["imdbphp"]["langauge"];
+		if($settings["imdbphp"]["language"])
+			$config->language = $settings["imdbphp"]["language"];
 		if($settings["imdbphp"]["ip_address"])
 			$config->ip_address = $settings["imdbphp"]["ip_address"];
 		if($settings["imdbphp"]["debug"])
@@ -101,8 +101,8 @@ if(isset($_POST["movieid"])) {
 		
 		// IMDB config
 		$config = new \Imdb\Config();
-		if($settings["imdbphp"]["langauge"])
-			$config->language = $settings["imdbphp"]["langauge"];
+		if($settings["imdbphp"]["language"])
+			$config->language = $settings["imdbphp"]["language"];
 		if($settings["imdbphp"]["ip_address"])
 			$config->ip_address = $settings["imdbphp"]["ip_address"];
 		if($settings["imdbphp"]["debug"])


### PR DESCRIPTION
Since this will potentially break existing configurations, I'm not completely confident about how this fix should be rolled out.

Currently, the update process lacks a way to update given configuration files itself, so that some might not currently have the right permissions on that file.
Maybe it should only be read to verify that it does not contain `langauge` and hint to fix it in the config.php during update process?